### PR TITLE
feat(ai-dictionary): Add Gemini fallback chain

### DIFF
--- a/apps/my-website/src/app/api/define/route.ts
+++ b/apps/my-website/src/app/api/define/route.ts
@@ -18,7 +18,20 @@ export async function GET() {
 
 export async function POST(request: NextRequest) {
   try {
-    const { word } = await request.json();
+    let body: { word?: unknown };
+
+    try {
+      body = (await request.json()) as { word?: unknown };
+    } catch {
+      return NextResponse.json({ error: "請提供有效的 JSON 請求內容" }, { status: 400 });
+    }
+
+    const { word } = body;
+
+    if (typeof word !== "string") {
+      throw new Error("請提供有效的中文詞彙");
+    }
+
     logger.info({ word }, "Word analysis request received");
 
     // Get validated API key from env

--- a/apps/my-website/src/app/api/define/route.ts
+++ b/apps/my-website/src/app/api/define/route.ts
@@ -6,6 +6,10 @@ import { env } from "@/env";
 
 const logger = createLogger({ context: "api/define" });
 
+const isClientInputError = (message: string): boolean => {
+  return message === "請提供有效的中文詞彙" || message.startsWith("查詢詞彙過長");
+};
+
 // Handle unsupported HTTP methods
 export async function GET() {
   logger.warn({ method: "GET" }, "Unsupported HTTP method");
@@ -27,6 +31,8 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     logError("Word analysis failed", error, { route: "/api/define" });
     const errorMessage = error instanceof Error ? error.message : "未知錯誤";
-    return NextResponse.json({ error: errorMessage }, { status: 500 });
+    const status = isClientInputError(errorMessage) ? 400 : 500;
+
+    return NextResponse.json({ error: errorMessage }, { status });
   }
 }

--- a/packages/ai-dictionary/src/services/__tests__/dictionary.service.test.ts
+++ b/packages/ai-dictionary/src/services/__tests__/dictionary.service.test.ts
@@ -143,6 +143,32 @@ describe("analyzeWord", () => {
     expect(getGenerativeModel).toHaveBeenCalledTimes(2);
   });
 
+  it("falls back when the primary model has a model-specific access error", async () => {
+    const { getGenerativeModel } = setupModelResponses({
+      "gemini-3.1-flash-lite": new Error(
+        "User location is not supported for this model or access is denied",
+      ),
+      "gemini-2.5-flash-lite": validDictionaryResponse,
+    });
+
+    const result = await analyzeWord("學習", "test-api-key");
+
+    expect(result).toEqual(validDictionaryResponse);
+    expect(getGenerativeModel).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails fast when the API key is invalid", async () => {
+    const { getGenerativeModel } = setupModelResponses({
+      "gemini-3.1-flash-lite": new Error("API key not valid"),
+      "gemini-2.5-flash-lite": validDictionaryResponse,
+    });
+
+    await expect(analyzeWord("學習", "test-api-key")).rejects.toThrow(
+      "AI 字典服務設定異常，請聯繫管理員。",
+    );
+    expect(getGenerativeModel).toHaveBeenCalledTimes(1);
+  });
+
   it("throws a user-friendly error when all models fail", async () => {
     setupModelResponses({
       "gemini-3.1-flash-lite": new Error("RESOURCE_EXHAUSTED: quota exceeded"),

--- a/packages/ai-dictionary/src/services/__tests__/dictionary.service.test.ts
+++ b/packages/ai-dictionary/src/services/__tests__/dictionary.service.test.ts
@@ -1,0 +1,169 @@
+import { GoogleGenerativeAI } from "@google/generative-ai";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { analyzeWord } from "../dictionary.service";
+
+vi.mock("@google/generative-ai", () => ({
+  GoogleGenerativeAI: vi.fn(),
+}));
+
+vi.mock("@packages/shared/utils", async (importOriginal) => {
+  const actual = await importOriginal();
+
+  return {
+    ...(actual as object),
+    createLogger: () => ({
+      error: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+    }),
+  };
+});
+
+const validDictionaryResponse = {
+  queryWord: "學習",
+  definitions: [
+    {
+      partOfSpeech: "動詞",
+      meaning: "透過閱讀、練習或經驗取得知識與技能。",
+    },
+  ],
+  etymologyBlocks: [
+    {
+      type: "character",
+      char: "學",
+      pinyin: "xué",
+      zhuyin: "ㄒㄩㄝˊ",
+      etymology: "與求知、模仿相關。",
+    },
+  ],
+};
+
+const createGeminiResult = (response: unknown) => ({
+  response: {
+    text: () => JSON.stringify(response),
+  },
+});
+
+const setupModelResponses = (responsesByModel: Record<string, unknown>) => {
+  const generateContentByModel = new Map<string, ReturnType<typeof vi.fn>>();
+  const getGenerativeModel = vi.fn(({ model }: { model: string }) => {
+    const generateContent = vi.fn(async () => {
+      const response = responsesByModel[model];
+
+      if (response instanceof Error) {
+        throw response;
+      }
+
+      if (typeof response === "string") {
+        return {
+          response: {
+            text: () => response,
+          },
+        };
+      }
+
+      return createGeminiResult(response);
+    });
+
+    generateContentByModel.set(model, generateContent);
+
+    return { generateContent };
+  });
+
+  vi.mocked(GoogleGenerativeAI).mockImplementation(function () {
+    return { getGenerativeModel } as unknown as GoogleGenerativeAI;
+  });
+
+  return { generateContentByModel, getGenerativeModel };
+};
+
+describe("analyzeWord", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses the primary Gemini model when it succeeds", async () => {
+    const { getGenerativeModel } = setupModelResponses({
+      "gemini-3.1-flash-lite": validDictionaryResponse,
+    });
+
+    const result = await analyzeWord("學習", "test-api-key");
+
+    expect(result).toEqual(validDictionaryResponse);
+    expect(getGenerativeModel).toHaveBeenCalledTimes(1);
+    expect(getGenerativeModel).toHaveBeenCalledWith({
+      model: "gemini-3.1-flash-lite",
+    });
+  });
+
+  it("falls back when the primary model fails", async () => {
+    const { getGenerativeModel } = setupModelResponses({
+      "gemini-3.1-flash-lite": new Error("RESOURCE_EXHAUSTED: quota exceeded"),
+      "gemini-2.5-flash-lite": validDictionaryResponse,
+    });
+
+    const result = await analyzeWord("學習", "test-api-key");
+
+    expect(result).toEqual(validDictionaryResponse);
+    expect(getGenerativeModel).toHaveBeenCalledTimes(2);
+    expect(getGenerativeModel).toHaveBeenNthCalledWith(1, {
+      model: "gemini-3.1-flash-lite",
+    });
+    expect(getGenerativeModel).toHaveBeenNthCalledWith(2, {
+      model: "gemini-2.5-flash-lite",
+    });
+  });
+
+  it("falls back when the primary model returns invalid JSON", async () => {
+    const { getGenerativeModel } = setupModelResponses({
+      "gemini-3.1-flash-lite": "not-json",
+      "gemini-2.5-flash-lite": validDictionaryResponse,
+    });
+
+    const result = await analyzeWord("學習", "test-api-key");
+
+    expect(result).toEqual(validDictionaryResponse);
+    expect(getGenerativeModel).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back when the primary model returns an incomplete response", async () => {
+    const { getGenerativeModel } = setupModelResponses({
+      "gemini-3.1-flash-lite": {
+        queryWord: "學習",
+        definitions: [],
+        etymologyBlocks: [],
+      },
+      "gemini-2.5-flash-lite": validDictionaryResponse,
+    });
+
+    const result = await analyzeWord("學習", "test-api-key");
+
+    expect(result).toEqual(validDictionaryResponse);
+    expect(getGenerativeModel).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws a user-friendly error when all models fail", async () => {
+    setupModelResponses({
+      "gemini-3.1-flash-lite": new Error("RESOURCE_EXHAUSTED: quota exceeded"),
+      "gemini-2.5-flash-lite": new Error("rate-limits exceeded"),
+      "gemini-2.5-flash": new Error("quota exceeded"),
+    });
+
+    await expect(analyzeWord("學習", "test-api-key")).rejects.toThrow(
+      "AI 字典服務目前請求量過高或免費額度已用完，請稍後再試。",
+    );
+  });
+
+  it("does not call Gemini for invalid input", async () => {
+    const { getGenerativeModel } = setupModelResponses({
+      "gemini-3.1-flash-lite": validDictionaryResponse,
+    });
+
+    await expect(analyzeWord("", "test-api-key")).rejects.toThrow(
+      "請提供有效的中文詞彙",
+    );
+
+    expect(getGenerativeModel).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ai-dictionary/src/services/__tests__/dictionary.service.test.ts
+++ b/packages/ai-dictionary/src/services/__tests__/dictionary.service.test.ts
@@ -169,6 +169,18 @@ describe("analyzeWord", () => {
     expect(getGenerativeModel).toHaveBeenCalledTimes(1);
   });
 
+  it("fails fast for generic unauthorized errors", async () => {
+    const { getGenerativeModel } = setupModelResponses({
+      "gemini-3.1-flash-lite": new Error("401 Unauthorized access"),
+      "gemini-2.5-flash-lite": validDictionaryResponse,
+    });
+
+    await expect(analyzeWord("學習", "test-api-key")).rejects.toThrow(
+      "AI 字典服務設定異常，請聯繫管理員。",
+    );
+    expect(getGenerativeModel).toHaveBeenCalledTimes(1);
+  });
+
   it("throws a user-friendly error when all models fail", async () => {
     setupModelResponses({
       "gemini-3.1-flash-lite": new Error("RESOURCE_EXHAUSTED: quota exceeded"),

--- a/packages/ai-dictionary/src/services/dictionary.service.ts
+++ b/packages/ai-dictionary/src/services/dictionary.service.ts
@@ -1,15 +1,120 @@
 import { GoogleGenerativeAI } from "@google/generative-ai";
-import { GEMINI_2_5_FLASH_LITE, MAX_WORD_LENGTH } from "@packages/shared/constants";
+import {
+  DICTIONARY_GEMINI_FALLBACK_MODELS,
+  MAX_WORD_LENGTH,
+} from "@packages/shared/constants";
 import type { WordAnalysisResponse } from "@packages/shared/types";
+import type { AIErrorType } from "@packages/shared/utils";
+import { createLogger, parseAIErrorMessage } from "@packages/shared/utils";
 
 import { buildDictionaryPrompt } from "../prompts";
 import { cleanAIResponse, validateResponse } from "../utils";
 
+const logger = createLogger({ context: "ai-dictionary/service" });
+const AUTH_ERROR_MESSAGE = "AI 字典服務設定異常，請聯繫管理員。";
+const DEFAULT_FAILURE_MESSAGE = "AI 字典服務暫時無法完成分析，請稍後再試。";
+
+type DictionaryAttemptErrorType = AIErrorType | "invalid_response";
+
+interface DictionaryAttemptError {
+  model: string;
+  type: DictionaryAttemptErrorType;
+  message: string;
+}
+
+class DictionaryResponseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DictionaryResponseError";
+  }
+}
+
+const getErrorMessage = (error: unknown): string => {
+  return error instanceof Error ? error.message : String(error);
+};
+
+const toDictionaryAttemptError = (
+  model: string,
+  error: unknown,
+): DictionaryAttemptError => {
+  const message = getErrorMessage(error);
+
+  if (error instanceof DictionaryResponseError) {
+    return {
+      model,
+      type: "invalid_response",
+      message,
+    };
+  }
+
+  const parsedError = parseAIErrorMessage(message);
+
+  return {
+    model,
+    type: parsedError.type,
+    message,
+  };
+};
+
+const buildFailureMessage = (attemptErrors: DictionaryAttemptError[]): string => {
+  const errorTypes = new Set(attemptErrors.map((error) => error.type));
+
+  if (errorTypes.size === 0) {
+    return DEFAULT_FAILURE_MESSAGE;
+  }
+
+  if (
+    [...errorTypes].every((type) =>
+      type === "quota_exceeded" || type === "rate_limited"
+    )
+  ) {
+    return "AI 字典服務目前請求量過高或免費額度已用完，請稍後再試。";
+  }
+
+  if (errorTypes.has("model_unavailable")) {
+    return "AI 字典模型暫時不可用，請稍後再試。";
+  }
+
+  if (errorTypes.has("invalid_response")) {
+    return "AI 回應格式暫時異常，請稍後再試。";
+  }
+
+  if (errorTypes.has("network_error")) {
+    return "AI 字典服務連線暫時異常，請稍後再試。";
+  }
+
+  return DEFAULT_FAILURE_MESSAGE;
+};
+
+async function analyzeWordWithModel(
+  genAI: GoogleGenerativeAI,
+  modelName: string,
+  prompt: string,
+): Promise<WordAnalysisResponse> {
+  const model = genAI.getGenerativeModel({ model: modelName });
+  const result = await model.generateContent(prompt);
+  const text = result.response.text().trim();
+  const cleanedText = cleanAIResponse(text);
+
+  let parsedResponse: WordAnalysisResponse;
+
+  try {
+    parsedResponse = JSON.parse(cleanedText) as WordAnalysisResponse;
+  } catch {
+    throw new DictionaryResponseError("AI 回應格式錯誤");
+  }
+
+  if (!validateResponse(parsedResponse)) {
+    throw new DictionaryResponseError("AI 回應資料結構不完整");
+  }
+
+  return parsedResponse;
+}
+
 export async function analyzeWord(
   word: string,
-  apiKey: string
+  apiKey: string,
 ): Promise<WordAnalysisResponse> {
-  // 1. 驗證輸入
   if (!word || typeof word !== "string") {
     throw new Error("請提供有效的中文詞彙");
   }
@@ -18,31 +123,63 @@ export async function analyzeWord(
     throw new Error(`查詢詞彙過長,請勿超過 ${MAX_WORD_LENGTH} 個字元。`);
   }
 
-  // 2. 初始化 AI
   const genAI = new GoogleGenerativeAI(apiKey);
-  const model = genAI.getGenerativeModel({ model: GEMINI_2_5_FLASH_LITE });
-
-  // 3. 調用 AI
   const prompt = buildDictionaryPrompt(word);
-  const result = await model.generateContent(prompt);
-  const text = result.response.text().trim();
+  const attemptErrors: DictionaryAttemptError[] = [];
 
-  // 4. 處理回應
-  const cleanedText = cleanAIResponse(text);
+  for (const [index, modelName] of DICTIONARY_GEMINI_FALLBACK_MODELS.entries()) {
+    const attempt = index + 1;
 
-  try {
-    const parsedResponse: WordAnalysisResponse = JSON.parse(cleanedText);
+    try {
+      const response = await analyzeWordWithModel(genAI, modelName, prompt);
 
-    if (!validateResponse(parsedResponse)) {
-      console.error("AI 回應資料結構不完整:", parsedResponse);
-      throw new Error("AI 回應資料結構不完整");
+      logger.info(
+        { word, model: modelName, attempt },
+        "Dictionary analysis completed with model",
+      );
+
+      return response;
+    } catch (error) {
+      const attemptError = toDictionaryAttemptError(modelName, error);
+      attemptErrors.push(attemptError);
+
+      if (attemptError.type === "auth_error") {
+        logger.error(
+          { word, model: modelName, attempt, errorType: attemptError.type },
+          "Dictionary model attempt failed due to authentication error",
+        );
+        throw new Error(AUTH_ERROR_MESSAGE);
+      }
+
+      const nextModel = DICTIONARY_GEMINI_FALLBACK_MODELS[index + 1];
+
+      logger.warn(
+        {
+          word,
+          model: modelName,
+          attempt,
+          errorType: attemptError.type,
+          nextModel,
+        },
+        nextModel
+          ? "Dictionary model attempt failed; trying fallback"
+          : "Dictionary model attempt failed",
+      );
     }
-
-    return parsedResponse;
-  } catch (parseError) {
-    console.error("JSON 解析失敗:", parseError);
-    console.error("原始文字:", text);
-    console.error("清理後:", cleanedText);
-    throw new Error("AI 回應格式錯誤");
   }
+
+  logger.error(
+    {
+      word,
+      attemptedModels: DICTIONARY_GEMINI_FALLBACK_MODELS,
+      errors: attemptErrors.map((error) => ({
+        model: error.model,
+        type: error.type,
+        message: error.message,
+      })),
+    },
+    "Dictionary model chain failed",
+  );
+
+  throw new Error(buildFailureMessage(attemptErrors));
 }

--- a/packages/ai-dictionary/src/services/dictionary.service.ts
+++ b/packages/ai-dictionary/src/services/dictionary.service.ts
@@ -33,14 +33,21 @@ const getErrorMessage = (error: unknown): string => {
   return error instanceof Error ? error.message : String(error);
 };
 
-const isFatalAuthError = (message: string): boolean => {
+const isModelAccessError = (message: string, model: string): boolean => {
   const lowerMessage = message.toLowerCase();
+  const lowerModel = model.toLowerCase();
+  const mentionsModel =
+    lowerMessage.includes(lowerModel) || lowerMessage.includes("model");
 
   return (
-    lowerMessage.includes("api key not valid") ||
-    lowerMessage.includes("invalid api key") ||
-    lowerMessage.includes("api_key_invalid") ||
-    lowerMessage.includes("authentication failed")
+    mentionsModel &&
+    (lowerMessage.includes("access denied") ||
+      lowerMessage.includes("denied access") ||
+      lowerMessage.includes("permission denied") ||
+      lowerMessage.includes("not available") ||
+      lowerMessage.includes("not supported") ||
+      lowerMessage.includes("unsupported") ||
+      lowerMessage.includes("location"))
   );
 };
 
@@ -60,7 +67,7 @@ const toDictionaryAttemptError = (
 
   const parsedError = parseAIErrorMessage(message);
   const type =
-    parsedError.type === "auth_error" && !isFatalAuthError(message)
+    parsedError.type === "auth_error" && isModelAccessError(message, model)
       ? "model_unavailable"
       : parsedError.type;
 

--- a/packages/ai-dictionary/src/services/dictionary.service.ts
+++ b/packages/ai-dictionary/src/services/dictionary.service.ts
@@ -33,6 +33,17 @@ const getErrorMessage = (error: unknown): string => {
   return error instanceof Error ? error.message : String(error);
 };
 
+const isFatalAuthError = (message: string): boolean => {
+  const lowerMessage = message.toLowerCase();
+
+  return (
+    lowerMessage.includes("api key not valid") ||
+    lowerMessage.includes("invalid api key") ||
+    lowerMessage.includes("api_key_invalid") ||
+    lowerMessage.includes("authentication failed")
+  );
+};
+
 const toDictionaryAttemptError = (
   model: string,
   error: unknown,
@@ -48,10 +59,14 @@ const toDictionaryAttemptError = (
   }
 
   const parsedError = parseAIErrorMessage(message);
+  const type =
+    parsedError.type === "auth_error" && !isFatalAuthError(message)
+      ? "model_unavailable"
+      : parsedError.type;
 
   return {
     model,
-    type: parsedError.type,
+    type,
     message,
   };
 };

--- a/packages/shared/src/constants/aiModels.ts
+++ b/packages/shared/src/constants/aiModels.ts
@@ -1,7 +1,14 @@
 // Legacy constants (for backwards compatibility)
+export const GEMINI_3_1_FLASH_LITE = "gemini-3.1-flash-lite";
 export const GEMINI_2_5_FLASH_LITE = "gemini-2.5-flash-lite";
 export const GEMINI_2_5_PRO = "gemini-2.5-pro";
 export const GEMINI_2_5_FLASH = "gemini-2.5-flash";
+
+export const DICTIONARY_GEMINI_FALLBACK_MODELS = [
+  GEMINI_3_1_FLASH_LITE,
+  GEMINI_2_5_FLASH_LITE,
+  GEMINI_2_5_FLASH,
+] as const;
 
 // AI Chat Model Configuration
 // Last updated: 2025-01-05


### PR DESCRIPTION
## Summary

- Add a dictionary-specific Gemini fallback model chain with `gemini-3.1-flash-lite` as the primary model.
- Refactor AI Dictionary analysis to try fallback models on retryable/model/response-format failures.
- Add service tests for primary success, fallback success, invalid response fallback, all-model failure, and invalid input.

Closes #88

## Verification

- `pnpm check`
- `pnpm test:run packages/ai-dictionary/src/services/__tests__/dictionary.service.test.ts`
- Browser verification on `localhost:3000/ai-dictionary`
- Lightweight API pressure check: 10 total `/api/define` requests, all returned 200 with valid response shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)
