### PR TITLE
feat(ai-dictionary): Add language-aware definitions

### DIFF
--- a/apps/my-website/src/app/(zh-site)/ai-dictionary/page.tsx
+++ b/apps/my-website/src/app/(zh-site)/ai-dictionary/page.tsx
@@ -2,8 +2,8 @@ import { AIDictionaryFeature } from "@packages/ai-dictionary";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  description: "運用人工智慧技術，讓中文詞彙含義與字源更容易理解",
-  title: "AI 智能中文字典 - Henry Lee",
+  description: "運用人工智慧，以繁體中文理解中英文詞彙的常見意思與字源",
+  title: "AI 中英字源字典 - Henry Lee",
 };
 
 /**

--- a/apps/my-website/src/types/dictionary.types.ts
+++ b/apps/my-website/src/types/dictionary.types.ts
@@ -58,7 +58,7 @@ export interface WordAnalysisResponse {
  */
 export interface WordDefinition {
   meaning: string;
-  partOfSpeech: string;
+  partOfSpeech?: string;
 }
 
 /**

--- a/packages/ai-dictionary/package.json
+++ b/packages/ai-dictionary/package.json
@@ -29,6 +29,8 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "eslint": "^9",
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3",
     "typescript": "^5"
   }
 }

--- a/packages/ai-dictionary/src/components/AIDictionaryHeader.tsx
+++ b/packages/ai-dictionary/src/components/AIDictionaryHeader.tsx
@@ -4,10 +4,10 @@ const AIDictionaryHeader: React.FC = () => {
       <div className="container mx-auto px-6 py-8">
         <div className="mx-auto max-w-4xl">
           <h1 className="mb-2 text-3xl font-light text-slate-800">
-            AI 智能中文字典
+            AI 中英字源字典
             <span className="ml-3 rounded-md bg-blue-100 px-2 py-1 text-sm font-medium text-blue-700">Beta</span>
           </h1>
-          <p className="text-slate-600">運用人工智慧技術，讓中文詞彙含義與字源更容易理解</p>
+          <p className="text-slate-600">運用人工智慧，以繁體中文理解中英文詞彙的常見意思與字源</p>
         </div>
       </div>
     </div>

--- a/packages/ai-dictionary/src/components/EmptyState.tsx
+++ b/packages/ai-dictionary/src/components/EmptyState.tsx
@@ -13,7 +13,7 @@ const EmptyState: React.FC<EmptyStateProps> = ({ onOpenDonateModal }) => {
         <span className="text-2xl text-slate-400">📚</span>
       </div>
       <h3 className="mb-2 text-lg font-medium text-slate-700">開始您的詞彙探索之旅</h3>
-      <p className="text-slate-500">在上方搜索框輸入中文詞彙，開始深入了解其含義與字源</p>
+      <p className="text-slate-500">在上方搜尋框輸入中文或英文詞彙，深入了解它的常見意思與字源</p>
 
       {/* CTA 區塊 */}
       <div className="mt-12 flex flex-col items-center gap-4">

--- a/packages/ai-dictionary/src/components/WordCard/Definitions.tsx
+++ b/packages/ai-dictionary/src/components/WordCard/Definitions.tsx
@@ -23,7 +23,9 @@ const Definitions: React.FC<DefinitionsProps> = ({ definitions }) => (
               </span>
             </div>
           )}
-          <p className="mb-2 text-sm leading-relaxed break-words text-slate-700 sm:text-base">{def.meaning}</p>
+          <p className="mb-2 text-sm leading-relaxed break-words text-slate-700 sm:text-base">
+            {defIndex + 1}. {def.meaning}
+          </p>
         </div>
       ))}
     </div>

--- a/packages/ai-dictionary/src/components/WordCard/Definitions.tsx
+++ b/packages/ai-dictionary/src/components/WordCard/Definitions.tsx
@@ -16,9 +16,13 @@ const Definitions: React.FC<DefinitionsProps> = ({ definitions }) => (
     <div className="space-y-3">
       {definitions.map((def: WordDefinition, defIndex: number) => (
         <div className="rounded-lg border border-slate-200 p-3 sm:p-4" key={defIndex}>
-          <div className="mb-2 flex flex-wrap items-center gap-2">
-            <span className="rounded bg-blue-100 px-2 py-1 text-xs font-medium text-blue-800">{def.partOfSpeech}</span>
-          </div>
+          {def.partOfSpeech?.trim() && (
+            <div className="mb-2 flex flex-wrap items-center gap-2">
+              <span className="rounded bg-blue-100 px-2 py-1 text-xs font-medium text-blue-800">
+                {def.partOfSpeech}
+              </span>
+            </div>
+          )}
           <p className="mb-2 text-sm leading-relaxed break-words text-slate-700 sm:text-base">{def.meaning}</p>
         </div>
       ))}

--- a/packages/ai-dictionary/src/components/WordCard/__tests__/Definitions.test.tsx
+++ b/packages/ai-dictionary/src/components/WordCard/__tests__/Definitions.test.tsx
@@ -1,0 +1,37 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import Definitions from "../Definitions";
+
+describe("Definitions", () => {
+  it("renders part-of-speech badges for English definitions", () => {
+    const markup = renderToStaticMarkup(
+      <Definitions
+        definitions={[
+          { meaning: "一種紀錄。", partOfSpeech: "noun" },
+          { meaning: "把內容記錄下來。", partOfSpeech: "verb" },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("noun");
+    expect(markup).toContain("verb");
+    expect(markup).toContain("bg-blue-100");
+  });
+
+  it("does not render a badge wrapper when partOfSpeech is missing or blank", () => {
+    const markup = renderToStaticMarkup(
+      <Definitions
+        definitions={[
+          { meaning: "第一個中文意思。" },
+          { meaning: "第二個中文意思。", partOfSpeech: "   " },
+        ]}
+      />,
+    );
+
+    expect(markup).not.toContain("bg-blue-100");
+    expect(markup).not.toContain("mb-2 flex flex-wrap items-center gap-2");
+    expect(markup).not.toContain("undefined");
+    expect(markup.indexOf("第一個中文意思。")).toBeLessThan(markup.indexOf("第二個中文意思。"));
+  });
+});

--- a/packages/ai-dictionary/src/components/WordCard/__tests__/Definitions.test.tsx
+++ b/packages/ai-dictionary/src/components/WordCard/__tests__/Definitions.test.tsx
@@ -16,6 +16,8 @@ describe("Definitions", () => {
 
     expect(markup).toContain("noun");
     expect(markup).toContain("verb");
+    expect(markup).toContain("1. 一種紀錄。");
+    expect(markup).toContain("2. 把內容記錄下來。");
     expect(markup).toContain("bg-blue-100");
   });
 
@@ -32,6 +34,8 @@ describe("Definitions", () => {
     expect(markup).not.toContain("bg-blue-100");
     expect(markup).not.toContain("mb-2 flex flex-wrap items-center gap-2");
     expect(markup).not.toContain("undefined");
-    expect(markup.indexOf("第一個中文意思。")).toBeLessThan(markup.indexOf("第二個中文意思。"));
+    expect(markup).toContain("1. 第一個中文意思。");
+    expect(markup).toContain("2. 第二個中文意思。");
+    expect(markup.indexOf("1. 第一個中文意思。")).toBeLessThan(markup.indexOf("2. 第二個中文意思。"));
   });
 });

--- a/packages/ai-dictionary/src/components/WordSearchForm.tsx
+++ b/packages/ai-dictionary/src/components/WordSearchForm.tsx
@@ -42,7 +42,7 @@ const WordSearchForm: React.FC<WordSearchFormProps> = ({ isLoading, onSubmit }) 
               disabled={isLoading}
               maxLength={40}
               onChange={(e) => setInputWord(e.target.value)}
-              placeholder="輸入中文詞彙進行查詢..."
+              placeholder="輸入中文或英文詞彙..."
               type="text"
               value={inputWord}
             />

--- a/packages/ai-dictionary/src/prompts/__tests__/dictionary.prompt.test.ts
+++ b/packages/ai-dictionary/src/prompts/__tests__/dictionary.prompt.test.ts
@@ -65,6 +65,92 @@ describe("buildDictionaryPrompt", () => {
     expect(prompt).toContain("查詢中的「主」絕不能改成「之」");
   });
 
+  it("prioritizes the earliest known root before marking deeper origins unknown", () => {
+    const prompt = buildDictionaryPrompt("dog", true);
+
+    expect(prompt).toContain("追溯最早根源");
+    expect(prompt).toContain("目前可知、普遍接受的最早根源");
+    expect(prompt).toContain("最早可知的文字形式、來源語言或早期字形、當時本義");
+    expect(prompt).toContain("演變成現代形式或詞義的主要過程");
+    expect(prompt).toContain("不需列舉細微的學術爭議或少數假說");
+    expect(prompt).toContain("不得為了補齊鏈條而推測、翻譯或編造");
+    expect(prompt).toContain("必須先交代已知的最早可靠節點與演變");
+    expect(prompt).toContain("不得因最終根源未知而省略已知歷史");
+  });
+
+  it.each([
+    {
+      query: "來",
+      requiresPartOfSpeech: false,
+      expectedFragments: ["早期麥類象形與本義", "假借為「來」", "「麥」的分化"],
+    },
+    {
+      query: "莫",
+      requiresPartOfSpeech: false,
+      expectedFragments: ["日落草莽的早期字形與暮晚本義", "否定假借", "「暮」的分化"],
+    },
+    {
+      query: "北",
+      requiresPartOfSpeech: false,
+      expectedFragments: ["二人相背的早期字形與背離本義", "方位假借", "「背」的分化"],
+    },
+    {
+      query: "orange",
+      requiresPartOfSpeech: true,
+      expectedFragments: [
+        "Sanskrit → Persian → Arabic → Italian／Medieval Latin → Old French → English",
+        "字首 n 的重新切分",
+      ],
+    },
+    {
+      query: "algorithm",
+      requiresPartOfSpeech: true,
+      expectedFragments: [
+        "al-Khwarizmi 的姓名",
+        "Medieval Latin algorismus",
+        "Old French algorisme",
+        "Greek arithmos",
+        "French algorithme",
+      ],
+    },
+    {
+      query: "apron",
+      requiresPartOfSpeech: true,
+      expectedFragments: [
+        "Middle French naperon",
+        "Middle English napron",
+        "a napron 被重新切分為 an apron",
+      ],
+    },
+    {
+      query: "nickname",
+      requiresPartOfSpeech: true,
+      expectedFragments: [
+        "Old English eaca／eke + name",
+        "an ekename 被重新切分為 a nickname",
+      ],
+    },
+    {
+      query: "nightmare",
+      requiresPartOfSpeech: true,
+      expectedFragments: ["mare 早期指壓迫睡眠者的惡靈", "並非母馬"],
+    },
+    {
+      query: "dog",
+      requiresPartOfSpeech: true,
+      expectedFragments: ["Old English docga", "更早來源不詳", "不可只回答整體來源不詳"],
+    },
+  ])("includes the expected etymology depth guidance for $query", ({
+    query,
+    requiresPartOfSpeech,
+    expectedFragments,
+  }) => {
+    const prompt = buildDictionaryPrompt(query, requiresPartOfSpeech);
+
+    expect(prompt).toContain(`**使用者詞彙:** ${JSON.stringify(query)}`);
+    expectedFragments.forEach((fragment) => expect(prompt).toContain(fragment));
+  });
+
   it("describes etymology block shapes as alternatives", () => {
     const prompt = buildDictionaryPrompt("學習", false);
 

--- a/packages/ai-dictionary/src/prompts/__tests__/dictionary.prompt.test.ts
+++ b/packages/ai-dictionary/src/prompts/__tests__/dictionary.prompt.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { buildDictionaryPrompt } from "../dictionary.prompt";
+
+describe("buildDictionaryPrompt", () => {
+  it("omits partOfSpeech from the Chinese JSON schema", () => {
+    const prompt = buildDictionaryPrompt("學習", false);
+
+    expect(prompt).toContain("每個 definition 都不得包含 partOfSpeech");
+    expect(prompt).not.toContain('"partOfSpeech":');
+    expect(prompt).not.toContain("//");
+    expect(prompt).toContain('"etymologyBlocks"');
+  });
+
+  it("requires partOfSpeech in the English JSON schema", () => {
+    const prompt = buildDictionaryPrompt("record", true);
+
+    expect(prompt).toContain("每個 definition 都必須包含非空的 partOfSpeech");
+    expect(prompt).toContain('"partOfSpeech": "英文詞性');
+    expect(prompt).toContain('"meaning"');
+    expect(prompt).toContain('"etymologyBlocks"');
+    expect(prompt).not.toContain("**外來語複合詞語意結構順序範例:**");
+    expect(prompt).not.toContain("//");
+  });
+
+  it("keeps Chinese-form loanwords free of partOfSpeech", () => {
+    const prompt = buildDictionaryPrompt("咖啡", false);
+
+    expect(prompt).toContain('**使用者詞彙:** "咖啡"');
+    expect(prompt).not.toContain('"partOfSpeech":');
+    expect(prompt).toContain("歇斯底里的卡拉ok");
+    expect(prompt).toContain('"type": "foreign"');
+  });
+});

--- a/packages/ai-dictionary/src/prompts/__tests__/dictionary.prompt.test.ts
+++ b/packages/ai-dictionary/src/prompts/__tests__/dictionary.prompt.test.ts
@@ -19,16 +19,57 @@ describe("buildDictionaryPrompt", () => {
     expect(prompt).toContain('"partOfSpeech": "英文詞性');
     expect(prompt).toContain('"meaning"');
     expect(prompt).toContain('"etymologyBlocks"');
-    expect(prompt).not.toContain("**外來語複合詞語意結構順序範例:**");
+    expect(prompt).not.toContain("**外來語複合詞表面順序範例:**");
     expect(prompt).not.toContain("//");
   });
 
-  it("keeps Chinese-form loanwords free of partOfSpeech", () => {
+  it("limits analysis to the queried term without adding professional background", () => {
+    const prompt = buildDictionaryPrompt("越軌產品", false);
+
+    expect(prompt).toContain("山達基清字只是使用目的");
+    expect(prompt).toContain("不得因山達基或其他專業知識聯想到、改寫或補充");
+    expect(prompt).toContain("不展開理論、學派、術語背景、英文對應或其他專業補充");
+    expect(prompt).toContain("不得猜測為 Overts and Withholds");
+  });
+
+  it("does not treat translations or foreign concepts as foreign etymology", () => {
+    const prompt = buildDictionaryPrompt("貨幣主義者", false);
+
+    expect(prompt).toContain("翻譯結果、概念起源、可能的英文術語");
+    expect(prompt).toContain("不得因「主義」可翻譯為 -ism");
+    expect(prompt).toContain("不得加入 monetarism、monetarist 或學派背景");
+  });
+
+  it("preserves Chinese-form loanwords as foreign etymology", () => {
     const prompt = buildDictionaryPrompt("咖啡", false);
 
     expect(prompt).toContain('**使用者詞彙:** "咖啡"');
     expect(prompt).not.toContain('"partOfSpeech":');
-    expect(prompt).toContain("歇斯底里的卡拉ok");
-    expect(prompt).toContain('"type": "foreign"');
+    expect(prompt).toContain("可使用一個 foreign block");
+    expect(prompt).toContain("不得因它全是漢字就機械拆成 character");
+  });
+
+  it("keeps literal Latin and Han segments in query order", () => {
+    const prompt = buildDictionaryPrompt("AI工具", false);
+
+    expect(prompt).toContain("foreign（對應查詢中的 AI）→ character（工）→ character（具）");
+    expect(prompt).toContain("不得把整個詞合併成 foreign");
+    expect(prompt).toContain("依查詢表面順序放置");
+  });
+
+  it("requires character blocks to copy the original query character exactly", () => {
+    const prompt = buildDictionaryPrompt("民主主義者", false);
+
+    expect(prompt).toContain("逐字複製查詢中對應位置的原始漢字");
+    expect(prompt).toContain("不得以同音字、近形字或推測字替換");
+    expect(prompt).toContain("查詢中的「主」絕不能改成「之」");
+  });
+
+  it("describes etymology block shapes as alternatives", () => {
+    const prompt = buildDictionaryPrompt("學習", false);
+
+    expect(prompt).toContain("etymologyBlocks 可選物件形狀");
+    expect(prompt).toContain("每個元素只能使用上述其中一種物件形狀");
+    expect(prompt).toContain("不要求同時包含兩種類型");
   });
 });

--- a/packages/ai-dictionary/src/prompts/dictionary.prompt.ts
+++ b/packages/ai-dictionary/src/prompts/dictionary.prompt.ts
@@ -71,8 +71,16 @@ const buildAnalysisGuidelines = (word: string, requiresPartOfSpeech: boolean): s
     - 「越軌產品」：只分析查詢詞本身的常見意思與實際中文字源。不得猜測為 Overts and Withholds，也不得加入任何未出現在查詢中的山達基或其他專業術語。
     - 「咖啡」：表面形式本身是可考證的音譯外來語，可使用一個 foreign block 說明「咖啡」整體的實際來源；不得因它全是漢字就機械拆成 character。
     - 「AI工具」：必須依序輸出 foreign（對應查詢中的 AI）→ character（工）→ character（具）。不得把整個詞合併成 foreign，不得遺漏中文字，也不得加入 query 中沒有的英文術語。
-4.  **無法考證時**：
-    - 若字源或外來來源無法可靠確認，請明確標註「來源不詳」或「無法考證」，不得自行翻譯、推測或編造原詞與傳入歷史。
+4.  **追溯最早根源**：
+    - 字源分析應優先追溯目前可知、普遍接受的最早根源，說明最早可知的文字形式、來源語言或早期字形、當時本義，以及演變成現代形式或詞義的主要過程。
+    - 中文漢字應追溯可知的早期字形或造字本義，並簡要說明假借、分化與主要語義演變；英文或外來語應追溯可知的最早來源語言、早期形式與主要傳遞鏈，包括重新切分等關鍵變化。
+    - 不需列舉細微的學術爭議或少數假說，採用最常見、普遍接受的說法即可；但不得為了補齊鏈條而推測、翻譯或編造未知的原詞、語根、年代與傳入歷史。
+    - 必須先交代已知的最早可靠節點與演變；只有該節點以前的來源確實無法可靠確認時，才簡短標註「更早來源不詳」或「更早來源無法考證」，不得因最終根源未知而省略已知歷史。
+5.  **追溯深度範例 - 只示範應追溯的深度與演變機制**：
+    - 中文：「來」追溯早期麥類象形與本義，再說明假借為「來」及「麥」的分化；「莫」追溯日落草莽的早期字形與暮晚本義，再說明否定假借及「暮」的分化；「北」追溯二人相背的早期字形與背離本義，再說明方位假借及「背」的分化。
+    - 英文：「orange」追溯 Sanskrit → Persian → Arabic → Italian／Medieval Latin → Old French → English，以及字首 n 的重新切分；「algorithm」追溯 al-Khwarizmi 的姓名 → Medieval Latin algorismus → Old French algorisme → 受 Greek arithmos 影響的 French algorithme → English。
+    - 英文重新切分：「apron」追溯 Middle French naperon → Middle English napron → a napron 被重新切分為 an apron；「nickname」追溯 Old English eaca／eke + name → an ekename 被重新切分為 a nickname。
+    - 英文語義與未知邊界：「nightmare」應說明 mare 早期指壓迫睡眠者的惡靈，並非母馬；「dog」應先追溯 Old English docga，再說明其更早來源不詳，不可只回答整體來源不詳。
 `;
 };
 

--- a/packages/ai-dictionary/src/prompts/dictionary.prompt.ts
+++ b/packages/ai-dictionary/src/prompts/dictionary.prompt.ts
@@ -17,7 +17,7 @@ const compress = (prompt: string): string => {
  * 角色定義 - 靜態內容
  */
 const ROLE_DEFINITION =
-  "你是一位山達基清字專家，對中文詞彙和字源非常了解，熟悉多種語言的詞源，擅長用簡單、易懂的方式，幫助使用者徹底理解每個字詞的常見意思與來源，協助他們清除誤字，真正學會並能運用這個字詞。";
+  "你是一位協助使用者自行進行山達基清字的中英詞義與字源分析專家。山達基清字只是使用目的，不是額外術語推測來源。你的工作只限於提供使用者實際查詢詞彙的常見意思，以及該詞表面文字可考證的實際字源；不得因山達基或其他專業知識聯想到、改寫或補充使用者沒有查詢的術語。請使用簡單、易懂的繁體中文，讓使用者自行運用清字步驟。";
 
 const buildImportantReminders = (requiresPartOfSpeech: boolean): string => `
 **⚠️ 嚴格要求 - 必須遵守:**
@@ -58,15 +58,21 @@ const buildAnalysisGuidelines = (word: string, requiresPartOfSpeech: boolean): s
   return `
 **分析指南:**
 1.  **列出常見意思**：${definitionsGuideline}
+    - definitions 只列出查詢詞本身的常見意思，不展開理論、學派、術語背景、英文對應或其他專業補充。
 2.  **字源分析**：
-    - 請將所有字源分析內容（包含外來語來源、每個中文字的字源）**依照查詢詞彙的語意結構順序**，全部放在 etymologyBlocks 陣列中，不可自行調整或合併。
-    - 例如：「歇斯底里的卡拉ok」必須依序為：「歇斯底里」的外來語來源 →「的」的中文字源 →「卡拉ok」的外來語來源。
-    - 外來語請用 type: "foreign"，value 欄位填寫來源、語意、演變、傳入中文的過程等。
-    - 有中文字源的字請用 type: "character"，並填寫 char、zhuyin、pinyin、etymology。
+    - 只分析使用者查詢字串表面實際出現的文字。所有字源內容必須依照查詢字串的表面順序放在 etymologyBlocks，不可遺漏、重排、合併或加入查詢中沒有的語素。
+    - 每個 character block 的 char 必須逐字複製查詢中對應位置的原始漢字。輸出前必須再次逐字核對，不得以同音字、近形字或推測字替換（例如查詢中的「主」絕不能改成「之」）。
+    - type: "foreign" 只能用於兩種情況：(1) 查詢字串表面實際存在的非漢字外文片段；(2) 查詢表面的中文字本身是可考證的音譯外來語。value 只說明該表面形式的實際來源、演變與傳入過程。
+    - 中文詞可以翻成英文、中文後綴可對應 -ism 或 -ist、詞義源自外國理論或專業領域，都不代表該中文表面文字是 foreign。不得因翻譯結果、概念起源、可能的英文術語、山達基或其他 persona 聯想而新增 foreign block。
+    - type: "character" 用於查詢中實際出現且具有中文字源的單一漢字，並填寫 char、zhuyin、pinyin、etymology。
     - 不要回傳 foreignEtymology 或 characters 欄位，只能用 etymologyBlocks。
-3.  **嚴格對應每一字或語素**：
-    - etymologyBlocks 必須與查詢詞彙的每一個字或語素一一對應，不能省略、不能多加。
-    - 若某字來源不詳，請明確標註「來源不詳」或「無法考證」。
+3.  **分類範例 - 必須遵守其一般原則**：
+    - 「貨幣主義者」：只分析實際中文字。不得因「主義」可翻譯為 -ism 或「者」可對應 -ist 而建立 foreign；不得加入 monetarism、monetarist 或學派背景。
+    - 「越軌產品」：只分析查詢詞本身的常見意思與實際中文字源。不得猜測為 Overts and Withholds，也不得加入任何未出現在查詢中的山達基或其他專業術語。
+    - 「咖啡」：表面形式本身是可考證的音譯外來語，可使用一個 foreign block 說明「咖啡」整體的實際來源；不得因它全是漢字就機械拆成 character。
+    - 「AI工具」：必須依序輸出 foreign（對應查詢中的 AI）→ character（工）→ character（具）。不得把整個詞合併成 foreign，不得遺漏中文字，也不得加入 query 中沒有的英文術語。
+4.  **無法考證時**：
+    - 若字源或外來來源無法可靠確認，請明確標註「來源不詳」或「無法考證」，不得自行翻譯、推測或編造原詞與傳入歷史。
 `;
 };
 
@@ -89,7 +95,7 @@ const buildJSONStructure = (word: string, requiresPartOfSpeech: boolean): string
     ? ""
     : `
 
-**外來語複合詞語意結構順序範例:**
+**外來語複合詞表面順序範例:**
 {
   "queryWord": "歇斯底里的卡拉ok",
   "definitions": [
@@ -100,7 +106,7 @@ const buildJSONStructure = (word: string, requiresPartOfSpeech: boolean): string
   "etymologyBlocks": [
     {
       "type": "foreign",
-      "value": "歇斯底里..."
+      "value": "歇斯底里的實際音譯來源..."
     },
     {
       "type": "character",
@@ -111,7 +117,7 @@ const buildJSONStructure = (word: string, requiresPartOfSpeech: boolean): string
     },
     {
       "type": "foreign",
-      "value": "卡拉ok..."
+      "value": "卡拉ok 的實際外來來源..."
     }
   ]
 }`;
@@ -124,21 +130,26 @@ const buildJSONStructure = (word: string, requiresPartOfSpeech: boolean): string
     ${definitionStructure}
   ],
   "etymologyBlocks": [
-    {
-      "type": "foreign",
-      "value": "外來語來源說明..."
-    },
-    {
-      "type": "character",
-      "char": "有實際中文字源的單一字元",
-      "zhuyin": "該字元的注音符號",
-      "pinyin": "該字元的漢語拼音",
-      "etymology": "該字元的字源學分析"
-    }
+    "依查詢表面順序放置下列兩種物件之一；只輸出實際適用的物件，不要求同時包含兩種類型"
   ]
 }
 
-etymologyBlocks 必須依照語意結構順序排列，每一個字或語素都必須有對應區塊，不能省略、不能多加。${chineseLoanwordExample}`;
+**etymologyBlocks 可選物件形狀:**
+foreign 物件：
+{
+  "type": "foreign",
+  "value": "查詢中實際外文片段或可考證音譯形式的來源說明"
+}
+character 物件：
+{
+  "type": "character",
+  "char": "查詢中實際出現的單一漢字",
+  "zhuyin": "該字元的注音符號",
+  "pinyin": "該字元的漢語拼音",
+  "etymology": "該字元可考證的字源分析"
+}
+
+etymologyBlocks 每個元素只能使用上述其中一種物件形狀。實際需要哪些類型完全由 query 的表面文字及其可考證字源決定，不得為符合示例而憑空新增另一種類型。${chineseLoanwordExample}`;
 };
 
 /**

--- a/packages/ai-dictionary/src/prompts/dictionary.prompt.ts
+++ b/packages/ai-dictionary/src/prompts/dictionary.prompt.ts
@@ -19,10 +19,7 @@ const compress = (prompt: string): string => {
 const ROLE_DEFINITION =
   "你是一位山達基清字專家，對中文詞彙和字源非常了解，熟悉多種語言的詞源，擅長用簡單、易懂的方式，幫助使用者徹底理解每個字詞的常見意思與來源，協助他們清除誤字，真正學會並能運用這個字詞。";
 
-/**
- * 重要提醒 - 靜態內容
- */
-const IMPORTANT_REMINDERS = `
+const buildImportantReminders = (requiresPartOfSpeech: boolean): string => `
 **⚠️ 嚴格要求 - 必須遵守:**
 *   你的回傳內容必須是100%純粹的JSON格式，絕對不可以有任何其他內容。
 *   第一個字元必須是 { ，最後一個字元必須是 }。
@@ -30,11 +27,15 @@ const IMPORTANT_REMINDERS = `
 *   絕對禁止任何形式的 markdown 區塊（包括所有以三個 backtick 開頭的區塊，例如「三個 backtick 加 json」、「三個 backtick 加 text」等），只允許純 JSON。
 *   不要說 "好的" 、"以下是分析結果" 或任何開場白。
 *   如果你添加了任何非JSON內容，系統會報錯並要求重新處理。
-*   確保所有欄位都已填寫，沒有遺漏。definitions 陣列只需列出常見意思（包含詞性）。`;
+*   確保所有必要欄位都已填寫，沒有遺漏。definitions 陣列只需列出常見意思${
+  requiresPartOfSpeech
+    ? "，且每個 definition 都必須包含非空的 partOfSpeech。"
+    : "，且每個 definition 都不得包含 partOfSpeech。"
+}`;
 
 /**
  * 建立任務說明部分
- * @param word - 要查詢的中文詞彙（原始字串）
+ * @param word - 要查詢的詞彙（原始字串）
  */
 const buildTaskDescription = (word: string): string => {
   const userQuery = JSON.stringify(word);
@@ -46,12 +47,17 @@ const buildTaskDescription = (word: string): string => {
 
 /**
  * 建立分析指南部分
- * @param word - 要查詢的中文詞彙（原始字串）
+ * @param word - 要查詢的詞彙（原始字串）
+ * @param requiresPartOfSpeech - 是否需要在每個定義中提供詞性
  */
-const buildAnalysisGuidelines = (word: string): string => {
+const buildAnalysisGuidelines = (word: string, requiresPartOfSpeech: boolean): string => {
+  const definitionsGuideline = requiresPartOfSpeech
+    ? `請列出「${word}」的常見定義，每一個意思都要用簡單、易懂的繁體中文解釋，並在每個 definition 中以非空的 partOfSpeech 標明英文詞性。`
+    : `請列出「${word}」在中文裡的常見定義，每一個意思都要用簡單、易懂的語言解釋。中文詞彙不需要標明詞性，每個 definition 都不得包含 partOfSpeech。`;
+
   return `
 **分析指南:**
-1.  **列出常見意思**：請列出「${word}」在中文裡的常見定義，每一個意思都要用簡單、易懂的語言解釋，並標明詞性。
+1.  **列出常見意思**：${definitionsGuideline}
 2.  **字源分析**：
     - 請將所有字源分析內容（包含外來語來源、每個中文字的字源）**依照查詢詞彙的語意結構順序**，全部放在 etymologyBlocks 陣列中，不可自行調整或合併。
     - 例如：「歇斯底里的卡拉ok」必須依序為：「歇斯底里」的外來語來源 →「的」的中文字源 →「卡拉ok」的外來語來源。
@@ -66,42 +72,28 @@ const buildAnalysisGuidelines = (word: string): string => {
 
 /**
  * 建立 JSON 結構範例部分
- * @param word - 要查詢的中文詞彙（原始字串）
+ * @param word - 要查詢的詞彙（原始字串）
+ * @param requiresPartOfSpeech - 是否需要在每個定義中提供詞性
  */
-const buildJSONStructure = (word: string): string => {
+const buildJSONStructure = (word: string, requiresPartOfSpeech: boolean): string => {
   const userQuery = JSON.stringify(word);
-  return `
-**JSON 物件結構:**
-{
-  "queryWord": ${userQuery},
-  "definitions": [
-    {
-      "partOfSpeech": "詞性 (例如：名詞, 動詞, 形容詞)",
+  const definitionStructure = requiresPartOfSpeech
+    ? `{
+      "partOfSpeech": "英文詞性 (例如：noun, verb, adjective)",
+      "meaning": "簡單、易懂的繁體中文定義"
+    }`
+    : `{
       "meaning": "簡單、易懂的定義"
-    }
-  ],
-  "etymologyBlocks": [
-    {
-      "type": "foreign",
-      "value": "外來語來源說明..."
-    },
-    {
-      "type": "character",
-      "char": "有實際中文字源的單一字元",
-      "zhuyin": "該字元的注音符號",
-      "pinyin": "該字元的漢語拼音",
-      "etymology": "該字元的字源學分析"
-    }
-    // ...依照語意結構順序排列，且每一個字或語素都必須有對應區塊，不能省略、不能多加
-  ]
-}
+    }`;
+  const chineseLoanwordExample = requiresPartOfSpeech
+    ? ""
+    : `
 
-// 外來語複合詞語意結構順序範例：
+**外來語複合詞語意結構順序範例:**
 {
   "queryWord": "歇斯底里的卡拉ok",
   "definitions": [
     {
-      "partOfSpeech": "形容詞",
       "meaning": "..."
     }
   ],
@@ -121,23 +113,47 @@ const buildJSONStructure = (word: string): string => {
       "type": "foreign",
       "value": "卡拉ok..."
     }
-    // 每一個字或語素都必須有對應區塊，不能省略、不能多加
   ]
 }`;
+
+  return `
+**JSON 物件結構:**
+{
+  "queryWord": ${userQuery},
+  "definitions": [
+    ${definitionStructure}
+  ],
+  "etymologyBlocks": [
+    {
+      "type": "foreign",
+      "value": "外來語來源說明..."
+    },
+    {
+      "type": "character",
+      "char": "有實際中文字源的單一字元",
+      "zhuyin": "該字元的注音符號",
+      "pinyin": "該字元的漢語拼音",
+      "etymology": "該字元的字源學分析"
+    }
+  ]
+}
+
+etymologyBlocks 必須依照語意結構順序排列，每一個字或語素都必須有對應區塊，不能省略、不能多加。${chineseLoanwordExample}`;
 };
 
 /**
  * 組合所有提示詞組件，建立完整的字典查詢 Prompt
- * @param word - 要查詢的中文詞彙
+ * @param word - 要查詢的詞彙
+ * @param requiresPartOfSpeech - 是否需要在每個定義中提供詞性
  * @returns 完整的格式化 Prompt 字串
  */
-export const buildDictionaryPrompt = (word: string): string => {
+export const buildDictionaryPrompt = (word: string, requiresPartOfSpeech: boolean): string => {
   const promptComponents = [
     compress(ROLE_DEFINITION),
     compress(buildTaskDescription(word)),
-    compress(buildAnalysisGuidelines(word)),
-    buildJSONStructure(word),
-    compress(IMPORTANT_REMINDERS),
+    compress(buildAnalysisGuidelines(word, requiresPartOfSpeech)),
+    buildJSONStructure(word, requiresPartOfSpeech),
+    compress(buildImportantReminders(requiresPartOfSpeech)),
   ];
 
   return promptComponents.join(" ");

--- a/packages/ai-dictionary/src/services/__tests__/dictionary.service.test.ts
+++ b/packages/ai-dictionary/src/services/__tests__/dictionary.service.test.ts
@@ -20,11 +20,10 @@ vi.mock("@packages/shared/utils", async (importOriginal) => {
   };
 });
 
-const validDictionaryResponse = {
+const validChineseResponse = {
   queryWord: "學習",
   definitions: [
     {
-      partOfSpeech: "動詞",
       meaning: "透過閱讀、練習或經驗取得知識與技能。",
     },
   ],
@@ -37,6 +36,21 @@ const validDictionaryResponse = {
       etymology: "與求知、模仿相關。",
     },
   ],
+};
+
+const validEnglishResponse = {
+  queryWord: "record",
+  definitions: [
+    {
+      partOfSpeech: "noun",
+      meaning: "保存下來的資訊或事件資料。",
+    },
+    {
+      partOfSpeech: "verb",
+      meaning: "把聲音、影像或資訊保存下來。",
+    },
+  ],
+  etymologyBlocks: [{ type: "foreign", value: "源自拉丁語 recordari。" }],
 };
 
 const createGeminiResult = (response: unknown) => ({
@@ -85,27 +99,108 @@ describe("analyzeWord", () => {
 
   it("uses the primary Gemini model when it succeeds", async () => {
     const { getGenerativeModel } = setupModelResponses({
-      "gemini-3.1-flash-lite": validDictionaryResponse,
+      "gemini-3.1-flash-lite": validChineseResponse,
     });
 
     const result = await analyzeWord("學習", "test-api-key");
 
-    expect(result).toEqual(validDictionaryResponse);
+    expect(result).toEqual(validChineseResponse);
     expect(getGenerativeModel).toHaveBeenCalledTimes(1);
     expect(getGenerativeModel).toHaveBeenCalledWith({
       model: "gemini-3.1-flash-lite",
     });
   });
 
-  it("falls back when the primary model fails", async () => {
-    const { getGenerativeModel } = setupModelResponses({
-      "gemini-3.1-flash-lite": new Error("RESOURCE_EXHAUSTED: quota exceeded"),
-      "gemini-2.5-flash-lite": validDictionaryResponse,
+  it("removes partOfSpeech from Chinese responses without changing definitions or etymology", async () => {
+    const chineseResponseWithPartsOfSpeech = {
+      ...validChineseResponse,
+      definitions: [
+        { meaning: "取得知識或技能。", partOfSpeech: "動詞" },
+        { meaning: "學習的過程。", partOfSpeech: "名詞" },
+      ],
+    };
+    setupModelResponses({
+      "gemini-3.1-flash-lite": chineseResponseWithPartsOfSpeech,
     });
 
     const result = await analyzeWord("學習", "test-api-key");
 
-    expect(result).toEqual(validDictionaryResponse);
+    expect(result.definitions).toEqual([
+      { meaning: "取得知識或技能。" },
+      { meaning: "學習的過程。" },
+    ]);
+    expect(result.etymologyBlocks).toEqual(validChineseResponse.etymologyBlocks);
+  });
+
+  it("treats Chinese-form loanwords as Chinese", async () => {
+    const coffeeResponse = {
+      queryWord: "咖啡",
+      definitions: [{ meaning: "以咖啡豆製成的飲料。", partOfSpeech: "名詞" }],
+      etymologyBlocks: [{ type: "foreign", value: "由外語音譯而來。" }],
+    };
+    setupModelResponses({
+      "gemini-3.1-flash-lite": coffeeResponse,
+    });
+
+    const result = await analyzeWord("咖啡", "test-api-key");
+
+    expect(result.definitions).toEqual([{ meaning: "以咖啡豆製成的飲料。" }]);
+    expect(result.etymologyBlocks).toEqual(coffeeResponse.etymologyBlocks);
+  });
+
+  it("preserves partOfSpeech on every English definition", async () => {
+    setupModelResponses({
+      "gemini-3.1-flash-lite": validEnglishResponse,
+    });
+
+    const result = await analyzeWord("record", "test-api-key");
+
+    expect(result).toEqual(validEnglishResponse);
+  });
+
+  it("falls back when any English definition is missing partOfSpeech", async () => {
+    const { getGenerativeModel } = setupModelResponses({
+      "gemini-3.1-flash-lite": {
+        ...validEnglishResponse,
+        definitions: [
+          validEnglishResponse.definitions[0],
+          { meaning: "把聲音、影像或資訊保存下來。" },
+        ],
+      },
+      "gemini-2.5-flash-lite": validEnglishResponse,
+    });
+
+    const result = await analyzeWord("record", "test-api-key");
+
+    expect(result).toEqual(validEnglishResponse);
+    expect(getGenerativeModel).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports the existing response error when every model omits English partOfSpeech", async () => {
+    const incompleteEnglishResponse = {
+      ...validEnglishResponse,
+      definitions: [{ meaning: "缺少詞性的定義。" }],
+    };
+    setupModelResponses({
+      "gemini-3.1-flash-lite": incompleteEnglishResponse,
+      "gemini-2.5-flash-lite": incompleteEnglishResponse,
+      "gemini-2.5-flash": incompleteEnglishResponse,
+    });
+
+    await expect(analyzeWord("record", "test-api-key")).rejects.toThrow(
+      "AI 回應格式暫時異常，請稍後再試。",
+    );
+  });
+
+  it("falls back when the primary model fails", async () => {
+    const { getGenerativeModel } = setupModelResponses({
+      "gemini-3.1-flash-lite": new Error("RESOURCE_EXHAUSTED: quota exceeded"),
+      "gemini-2.5-flash-lite": validChineseResponse,
+    });
+
+    const result = await analyzeWord("學習", "test-api-key");
+
+    expect(result).toEqual(validChineseResponse);
     expect(getGenerativeModel).toHaveBeenCalledTimes(2);
     expect(getGenerativeModel).toHaveBeenNthCalledWith(1, {
       model: "gemini-3.1-flash-lite",
@@ -118,12 +213,12 @@ describe("analyzeWord", () => {
   it("falls back when the primary model returns invalid JSON", async () => {
     const { getGenerativeModel } = setupModelResponses({
       "gemini-3.1-flash-lite": "not-json",
-      "gemini-2.5-flash-lite": validDictionaryResponse,
+      "gemini-2.5-flash-lite": validChineseResponse,
     });
 
     const result = await analyzeWord("學習", "test-api-key");
 
-    expect(result).toEqual(validDictionaryResponse);
+    expect(result).toEqual(validChineseResponse);
     expect(getGenerativeModel).toHaveBeenCalledTimes(2);
   });
 
@@ -134,12 +229,12 @@ describe("analyzeWord", () => {
         definitions: [],
         etymologyBlocks: [],
       },
-      "gemini-2.5-flash-lite": validDictionaryResponse,
+      "gemini-2.5-flash-lite": validChineseResponse,
     });
 
     const result = await analyzeWord("學習", "test-api-key");
 
-    expect(result).toEqual(validDictionaryResponse);
+    expect(result).toEqual(validChineseResponse);
     expect(getGenerativeModel).toHaveBeenCalledTimes(2);
   });
 
@@ -148,19 +243,19 @@ describe("analyzeWord", () => {
       "gemini-3.1-flash-lite": new Error(
         "User location is not supported for this model or access is denied",
       ),
-      "gemini-2.5-flash-lite": validDictionaryResponse,
+      "gemini-2.5-flash-lite": validChineseResponse,
     });
 
     const result = await analyzeWord("學習", "test-api-key");
 
-    expect(result).toEqual(validDictionaryResponse);
+    expect(result).toEqual(validChineseResponse);
     expect(getGenerativeModel).toHaveBeenCalledTimes(2);
   });
 
   it("fails fast when the API key is invalid", async () => {
     const { getGenerativeModel } = setupModelResponses({
       "gemini-3.1-flash-lite": new Error("API key not valid"),
-      "gemini-2.5-flash-lite": validDictionaryResponse,
+      "gemini-2.5-flash-lite": validChineseResponse,
     });
 
     await expect(analyzeWord("學習", "test-api-key")).rejects.toThrow(
@@ -172,7 +267,7 @@ describe("analyzeWord", () => {
   it("fails fast for generic unauthorized errors", async () => {
     const { getGenerativeModel } = setupModelResponses({
       "gemini-3.1-flash-lite": new Error("401 Unauthorized access"),
-      "gemini-2.5-flash-lite": validDictionaryResponse,
+      "gemini-2.5-flash-lite": validChineseResponse,
     });
 
     await expect(analyzeWord("學習", "test-api-key")).rejects.toThrow(
@@ -195,7 +290,7 @@ describe("analyzeWord", () => {
 
   it("does not call Gemini for invalid input", async () => {
     const { getGenerativeModel } = setupModelResponses({
-      "gemini-3.1-flash-lite": validDictionaryResponse,
+      "gemini-3.1-flash-lite": validChineseResponse,
     });
 
     await expect(analyzeWord("", "test-api-key")).rejects.toThrow(

--- a/packages/ai-dictionary/src/services/__tests__/dictionary.service.test.ts
+++ b/packages/ai-dictionary/src/services/__tests__/dictionary.service.test.ts
@@ -148,6 +148,58 @@ describe("analyzeWord", () => {
     expect(result.etymologyBlocks).toEqual(coffeeResponse.etymologyBlocks);
   });
 
+  it("preserves mixed foreign and character blocks in query order", async () => {
+    const mixedResponse = {
+      queryWord: "AI工具",
+      definitions: [{ meaning: "使用人工智慧協助工作的工具。" }],
+      etymologyBlocks: [
+        { type: "foreign", value: "AI 是 artificial intelligence 的縮寫。" },
+        { type: "character", char: "工", zhuyin: "ㄍㄨㄥ", pinyin: "gōng", etymology: "本義與工具有關。" },
+        { type: "character", char: "具", zhuyin: "ㄐㄩˋ", pinyin: "jù", etymology: "本義為備辦。" },
+      ],
+    };
+    setupModelResponses({
+      "gemini-3.1-flash-lite": mixedResponse,
+    });
+
+    const result = await analyzeWord("AI工具", "test-api-key");
+
+    expect(result).toEqual(mixedResponse);
+  });
+
+  it.each([
+    {
+      queryWord: "貨幣主義者",
+      definitions: [{ meaning: "支持貨幣主義的人。" }],
+      characters: ["貨", "幣", "主", "義", "者"],
+    },
+    {
+      queryWord: "越軌產品",
+      definitions: [{ meaning: "偏離既定規範的產品。" }],
+      characters: ["越", "軌", "產", "品"],
+    },
+  ])("preserves character-only etymology for $queryWord", async ({ queryWord, definitions, characters }) => {
+    const characterResponse = {
+      queryWord,
+      definitions,
+      etymologyBlocks: characters.map((char) => ({
+        type: "character",
+        char,
+        zhuyin: "ㄗˋ",
+        pinyin: "zì",
+        etymology: `${char}的字源。`,
+      })),
+    };
+    setupModelResponses({
+      "gemini-3.1-flash-lite": characterResponse,
+    });
+
+    const result = await analyzeWord(queryWord, "test-api-key");
+
+    expect(result).toEqual(characterResponse);
+    expect(result.etymologyBlocks.every((block) => block.type === "character")).toBe(true);
+  });
+
   it("preserves partOfSpeech on every English definition", async () => {
     setupModelResponses({
       "gemini-3.1-flash-lite": validEnglishResponse,
@@ -236,6 +288,37 @@ describe("analyzeWord", () => {
 
     expect(result).toEqual(validChineseResponse);
     expect(getGenerativeModel).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back when the primary model returns a malformed etymology block", async () => {
+    const { getGenerativeModel } = setupModelResponses({
+      "gemini-3.1-flash-lite": {
+        ...validChineseResponse,
+        etymologyBlocks: [{ type: "foreign", value: "   " }],
+      },
+      "gemini-2.5-flash-lite": validChineseResponse,
+    });
+
+    const result = await analyzeWord("學習", "test-api-key");
+
+    expect(result).toEqual(validChineseResponse);
+    expect(getGenerativeModel).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports the existing response error when every model returns malformed etymology", async () => {
+    const malformedResponse = {
+      ...validChineseResponse,
+      etymologyBlocks: [{ type: "character", char: "學" }],
+    };
+    setupModelResponses({
+      "gemini-3.1-flash-lite": malformedResponse,
+      "gemini-2.5-flash-lite": malformedResponse,
+      "gemini-2.5-flash": malformedResponse,
+    });
+
+    await expect(analyzeWord("學習", "test-api-key")).rejects.toThrow(
+      "AI 回應格式暫時異常，請稍後再試。",
+    );
   });
 
   it("falls back when the primary model has a model-specific access error", async () => {

--- a/packages/ai-dictionary/src/services/dictionary.service.ts
+++ b/packages/ai-dictionary/src/services/dictionary.service.ts
@@ -8,7 +8,7 @@ import type { AIErrorType } from "@packages/shared/utils";
 import { createLogger, parseAIErrorMessage } from "@packages/shared/utils";
 
 import { buildDictionaryPrompt } from "../prompts";
-import { cleanAIResponse, validateResponse } from "../utils";
+import { cleanAIResponse, requiresPartOfSpeech, validateResponse } from "../utils";
 
 const logger = createLogger({ context: "ai-dictionary/service" });
 const AUTH_ERROR_MESSAGE = "AI 字典服務設定異常，請聯繫管理員。";
@@ -112,25 +112,33 @@ async function analyzeWordWithModel(
   genAI: GoogleGenerativeAI,
   modelName: string,
   prompt: string,
+  shouldIncludePartOfSpeech: boolean,
 ): Promise<WordAnalysisResponse> {
   const model = genAI.getGenerativeModel({ model: modelName });
   const result = await model.generateContent(prompt);
   const text = result.response.text().trim();
   const cleanedText = cleanAIResponse(text);
 
-  let parsedResponse: WordAnalysisResponse;
+  let parsedResponse: unknown;
 
   try {
-    parsedResponse = JSON.parse(cleanedText) as WordAnalysisResponse;
+    parsedResponse = JSON.parse(cleanedText) as unknown;
   } catch {
     throw new DictionaryResponseError("AI 回應格式錯誤");
   }
 
-  if (!validateResponse(parsedResponse)) {
+  if (!validateResponse(parsedResponse, shouldIncludePartOfSpeech)) {
     throw new DictionaryResponseError("AI 回應資料結構不完整");
   }
 
-  return parsedResponse;
+  if (shouldIncludePartOfSpeech) {
+    return parsedResponse;
+  }
+
+  return {
+    ...parsedResponse,
+    definitions: parsedResponse.definitions.map(({ partOfSpeech: _partOfSpeech, ...definition }) => definition),
+  };
 }
 
 export async function analyzeWord(
@@ -146,14 +154,20 @@ export async function analyzeWord(
   }
 
   const genAI = new GoogleGenerativeAI(apiKey);
-  const prompt = buildDictionaryPrompt(word);
+  const shouldIncludePartOfSpeech = requiresPartOfSpeech(word);
+  const prompt = buildDictionaryPrompt(word, shouldIncludePartOfSpeech);
   const attemptErrors: DictionaryAttemptError[] = [];
 
   for (const [index, modelName] of DICTIONARY_GEMINI_FALLBACK_MODELS.entries()) {
     const attempt = index + 1;
 
     try {
-      const response = await analyzeWordWithModel(genAI, modelName, prompt);
+      const response = await analyzeWordWithModel(
+        genAI,
+        modelName,
+        prompt,
+        shouldIncludePartOfSpeech,
+      );
 
       logger.info(
         { word, model: modelName, attempt },

--- a/packages/ai-dictionary/src/utils/__tests__/queryLanguage.test.ts
+++ b/packages/ai-dictionary/src/utils/__tests__/queryLanguage.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { requiresPartOfSpeech } from "../queryLanguage";
+
+describe("requiresPartOfSpeech", () => {
+  it.each([
+    ["學習", false],
+    ["咖啡", false],
+    ["AI 工具", false],
+    ["卡拉OK", false],
+    ["learning", true],
+    ["take off", true],
+    ["café", true],
+    ["ＣＯＦＦＥＥ", true],
+    ["state-of-the-art", true],
+    ["don't", true],
+    ["Web 3.0", true],
+    ["カフェ", false],
+    ["커피", false],
+    ["кофе", false],
+    ["123", false],
+    ["?!", false],
+  ])("returns %s for %s", (query, expected) => {
+    expect(requiresPartOfSpeech(query)).toBe(expected);
+  });
+});

--- a/packages/ai-dictionary/src/utils/__tests__/validateResponse.test.ts
+++ b/packages/ai-dictionary/src/utils/__tests__/validateResponse.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { validateResponse } from "../validateResponse";
+
+const createResponse = (definitions: unknown) => ({
+  queryWord: "word",
+  definitions,
+  etymologyBlocks: [],
+});
+
+describe("validateResponse", () => {
+  it("accepts Chinese definitions without partOfSpeech", () => {
+    expect(validateResponse(createResponse([{ meaning: "一個常見意思。" }]), false)).toBe(true);
+  });
+
+  it("accepts Chinese definitions that will be normalized later", () => {
+    expect(
+      validateResponse(createResponse([{ meaning: "一個常見意思。", partOfSpeech: "名詞" }]), false),
+    ).toBe(true);
+  });
+
+  it("requires a non-empty partOfSpeech on every English definition", () => {
+    expect(
+      validateResponse(
+        createResponse([
+          { meaning: "第一個意思。", partOfSpeech: "noun" },
+          { meaning: "第二個意思。", partOfSpeech: "verb" },
+        ]),
+        true,
+      ),
+    ).toBe(true);
+
+    expect(
+      validateResponse(
+        createResponse([
+          { meaning: "第一個意思。", partOfSpeech: "noun" },
+          { meaning: "第二個意思。" },
+        ]),
+        true,
+      ),
+    ).toBe(false);
+
+    expect(validateResponse(createResponse([{ meaning: "一個意思。", partOfSpeech: "   " }]), true)).toBe(
+      false,
+    );
+  });
+
+  it("rejects malformed responses and empty meanings", () => {
+    expect(validateResponse(null, false)).toBe(false);
+    expect(validateResponse(createResponse([]), false)).toBe(false);
+    expect(validateResponse(createResponse([{ meaning: "" }]), false)).toBe(false);
+    expect(validateResponse({ queryWord: "word", definitions: [{}] }, false)).toBe(false);
+  });
+});

--- a/packages/ai-dictionary/src/utils/__tests__/validateResponse.test.ts
+++ b/packages/ai-dictionary/src/utils/__tests__/validateResponse.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import { validateResponse } from "../validateResponse";
 
-const createResponse = (definitions: unknown) => ({
+const createResponse = (definitions: unknown, etymologyBlocks: unknown = []) => ({
   queryWord: "word",
   definitions,
-  etymologyBlocks: [],
+  etymologyBlocks,
 });
 
 describe("validateResponse", () => {
@@ -43,6 +43,38 @@ describe("validateResponse", () => {
     expect(validateResponse(createResponse([{ meaning: "一個意思。", partOfSpeech: "   " }]), true)).toBe(
       false,
     );
+  });
+
+  it("accepts valid foreign, character, and mixed etymology blocks", () => {
+    const definition = [{ meaning: "一個常見意思。" }];
+    const foreignBlock = { type: "foreign", value: "源自外語音譯。" };
+    const characterBlock = {
+      type: "character",
+      char: "工",
+      zhuyin: "ㄍㄨㄥ",
+      pinyin: "gōng",
+      etymology: "本義與工具製作有關。",
+    };
+
+    expect(validateResponse(createResponse(definition, [foreignBlock]), false)).toBe(true);
+    expect(validateResponse(createResponse(definition, [characterBlock]), false)).toBe(true);
+    expect(validateResponse(createResponse(definition, [foreignBlock, characterBlock]), false)).toBe(true);
+  });
+
+  it.each([
+    null,
+    "foreign",
+    {},
+    { type: "unknown", value: "內容" },
+    { type: "foreign" },
+    { type: "foreign", value: "   " },
+    { type: "character", char: "字", zhuyin: "ㄗˋ", pinyin: "zì" },
+    { type: "character", char: " ", zhuyin: "ㄗˋ", pinyin: "zì", etymology: "字源" },
+    { type: "character", char: "字", zhuyin: " ", pinyin: "zì", etymology: "字源" },
+    { type: "character", char: "字", zhuyin: "ㄗˋ", pinyin: " ", etymology: "字源" },
+    { type: "character", char: "字", zhuyin: "ㄗˋ", pinyin: "zì", etymology: " " },
+  ])("rejects malformed etymology block %#", (block) => {
+    expect(validateResponse(createResponse([{ meaning: "一個常見意思。" }], [block]), false)).toBe(false);
   });
 
   it("rejects malformed responses and empty meanings", () => {

--- a/packages/ai-dictionary/src/utils/index.ts
+++ b/packages/ai-dictionary/src/utils/index.ts
@@ -1,2 +1,3 @@
 export { cleanAIResponse } from "./cleanAIResponse";
+export { requiresPartOfSpeech } from "./queryLanguage";
 export { validateResponse } from "./validateResponse";

--- a/packages/ai-dictionary/src/utils/queryLanguage.ts
+++ b/packages/ai-dictionary/src/utils/queryLanguage.ts
@@ -1,0 +1,18 @@
+const HAN_SCRIPT_PATTERN = /\p{Script=Han}/u;
+const LATIN_SCRIPT_PATTERN = /\p{Script=Latin}/u;
+const LETTER_PATTERN = /\p{Letter}/u;
+const LATIN_OR_NEUTRAL_PATTERN = /^[\p{Script=Latin}\p{Mark}\p{Number}\p{Separator}\p{Punctuation}\p{Symbol}]+$/u;
+
+export const requiresPartOfSpeech = (query: string): boolean => {
+  const normalizedQuery = query.normalize("NFKC").trim();
+
+  if (!normalizedQuery || HAN_SCRIPT_PATTERN.test(normalizedQuery)) {
+    return false;
+  }
+
+  return (
+    LETTER_PATTERN.test(normalizedQuery) &&
+    LATIN_SCRIPT_PATTERN.test(normalizedQuery) &&
+    LATIN_OR_NEUTRAL_PATTERN.test(normalizedQuery)
+  );
+};

--- a/packages/ai-dictionary/src/utils/validateResponse.ts
+++ b/packages/ai-dictionary/src/utils/validateResponse.ts
@@ -1,5 +1,31 @@
 import type { WordAnalysisResponse } from "@packages/shared/types";
 
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === "string" && !!value.trim();
+
+const isValidEtymologyBlock = (block: unknown): boolean => {
+  if (typeof block !== "object" || block === null) {
+    return false;
+  }
+
+  const candidateBlock = block as Record<string, unknown>;
+
+  if (candidateBlock.type === "foreign") {
+    return isNonEmptyString(candidateBlock.value);
+  }
+
+  if (candidateBlock.type === "character") {
+    return (
+      isNonEmptyString(candidateBlock.char) &&
+      isNonEmptyString(candidateBlock.zhuyin) &&
+      isNonEmptyString(candidateBlock.pinyin) &&
+      isNonEmptyString(candidateBlock.etymology)
+    );
+  }
+
+  return false;
+};
+
 /**
  * 驗證 AI 回應的結構是否符合當次查詢的詞性契約
  */
@@ -23,20 +49,19 @@ export function validateResponse(
     return false;
   }
 
-  return candidate.definitions.every((definition) => {
+  const hasValidDefinitions = candidate.definitions.every((definition) => {
     if (typeof definition !== "object" || definition === null) {
       return false;
     }
 
     const candidateDefinition = definition as Record<string, unknown>;
 
-    if (typeof candidateDefinition.meaning !== "string" || !candidateDefinition.meaning.trim()) {
+    if (!isNonEmptyString(candidateDefinition.meaning)) {
       return false;
     }
 
-    return (
-      !requiresPartOfSpeech ||
-      (typeof candidateDefinition.partOfSpeech === "string" && !!candidateDefinition.partOfSpeech.trim())
-    );
+    return !requiresPartOfSpeech || isNonEmptyString(candidateDefinition.partOfSpeech);
   });
+
+  return hasValidDefinitions && candidate.etymologyBlocks.every(isValidEtymologyBlock);
 }

--- a/packages/ai-dictionary/src/utils/validateResponse.ts
+++ b/packages/ai-dictionary/src/utils/validateResponse.ts
@@ -1,15 +1,42 @@
 import type { WordAnalysisResponse } from "@packages/shared/types";
 
 /**
- * 驗證 AI 回應的結構是否完整
+ * 驗證 AI 回應的結構是否符合當次查詢的詞性契約
  */
-export function validateResponse(response: WordAnalysisResponse): boolean {
-  return !!(
-    response.queryWord &&
-    response.definitions &&
-    Array.isArray(response.definitions) &&
-    response.etymologyBlocks &&
-    Array.isArray(response.etymologyBlocks) &&
-    response.definitions.length > 0
-  );
+export function validateResponse(
+  response: unknown,
+  requiresPartOfSpeech: boolean,
+): response is WordAnalysisResponse {
+  if (typeof response !== "object" || response === null) {
+    return false;
+  }
+
+  const candidate = response as Record<string, unknown>;
+
+  if (
+    typeof candidate.queryWord !== "string" ||
+    !candidate.queryWord.trim() ||
+    !Array.isArray(candidate.definitions) ||
+    candidate.definitions.length === 0 ||
+    !Array.isArray(candidate.etymologyBlocks)
+  ) {
+    return false;
+  }
+
+  return candidate.definitions.every((definition) => {
+    if (typeof definition !== "object" || definition === null) {
+      return false;
+    }
+
+    const candidateDefinition = definition as Record<string, unknown>;
+
+    if (typeof candidateDefinition.meaning !== "string" || !candidateDefinition.meaning.trim()) {
+      return false;
+    }
+
+    return (
+      !requiresPartOfSpeech ||
+      (typeof candidateDefinition.partOfSpeech === "string" && !!candidateDefinition.partOfSpeech.trim())
+    );
+  });
 }

--- a/packages/shared/src/types/dictionary.types.ts
+++ b/packages/shared/src/types/dictionary.types.ts
@@ -58,7 +58,7 @@ export interface WordAnalysisResponse {
  */
 export interface WordDefinition {
   meaning: string;
-  partOfSpeech: string;
+  partOfSpeech?: string;
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -288,6 +288,12 @@ importers:
       eslint:
         specifier: ^9
         version: 9.39.2(jiti@2.6.1)
+      react:
+        specifier: ~19.2.3
+        version: 19.2.3
+      react-dom:
+        specifier: ~19.2.3
+        version: 19.2.3(react@19.2.3)
       typescript:
         specifier: ~5.8.3
         version: 5.8.3


### PR DESCRIPTION
## Summary

- determine whether definitions require `partOfSpeech` from the query script
- omit Chinese part-of-speech badges while preserving them for English definitions
- number definition entries and rename the feature to AI 中英字源字典
- constrain etymology classification to the queried surface form and validate every etymology block
- add prompt contracts, language detection, response validation, service fallback, and UI tests

## Validation

- `pnpm run test:run` — 101 tests passed
- `pnpm run check` — 11 Turbo tasks passed
- browser verification through the real `/api/define` route
- live Gemini evaluation covered Chinese, English, loanword, mixed-script, and generalization cases

## Live evaluation examples

- `貨幣主義者` → character blocks only
- `越軌產品` → character blocks only, without unrelated Scientology terminology
- `咖啡` → one foreign etymology block
- `AI工具` → foreign(AI) → character(工) → character(具)
- `record` → every definition retains an English part of speech

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)